### PR TITLE
Add world module and utilities documentation

### DIFF
--- a/doc/core.md
+++ b/doc/core.md
@@ -1,0 +1,52 @@
+# Core Module Reference
+
+This document summarizes the key classes defined in `multi_pinhole.core` and how they collaborate to simulate a multi-eye imaging system.
+
+## Rays
+`Rays` is an immutable dataclass that carries the geometric result of tracing scene points through an eye. It records:
+
+* `Z`: the optical-axis distance from the eye to each point, preserving the sign so callers can distinguish front- and back-facing samples.【F:multi_pinhole/core.py†L101-L123】
+* `XY`: projected impact locations on the screen in camera Cartesian coordinates, with samples behind the eye left as `NaN` to simplify masking.【F:multi_pinhole/core.py†L101-L123】【F:multi_pinhole/core.py†L366-L370】
+* `zoom_rate`: the magnification factor `(1 + f/Z)` needed to dilate the eye footprint before rasterization.【F:multi_pinhole/core.py†L101-L123】【F:multi_pinhole/core.py†L368-L370】
+* `front_and_visible`: Boolean flags that encode both geometric visibility and aperture occlusion checks.【F:multi_pinhole/core.py†L101-L130】【F:multi_pinhole/core.py†L363-L372】
+
+Light-weight helpers (`n`, `n_visible`) expose counts of the total rays created and the subset that will contribute to the final image, making it easy for screening code to size sparse buffers or short-circuit empty jobs.【F:multi_pinhole/core.py†L124-L130】 As a pure data object, `Rays` sits between `Eye.calc_rays` and the `Screen` rasterizers.
+
+## Filter
+`Filter` stores the transmissive element mounted ahead of the eyes. Construction captures the material name, physical thickness, and either wavelength or photon-energy bounds, converting wavelengths to energy on the fly so the rest of the pipeline can work in a single energy domain.【F:multi_pinhole/core.py†L133-L165】  If neither bound is supplied, it defaults to a wide hard-coded energy range suited to X-ray simulations.【F:multi_pinhole/core.py†L159-L165】  Calling `get_data` lazily fetches a tabulated attenuation curve from `utils.filter`, caching it on the instance for reuse in later optical calculations.【F:multi_pinhole/core.py†L167-L168】
+
+## Eye
+An `Eye` models a single pinhole or concave lens, encapsulating its placement, field-of-view, and spectral band. During initialization it:
+
+* Normalizes the `eye_type` (pinhole vs. concave lens) while enforcing consistent focal-length sign conventions and converting the 2D mount location into a full camera-frame position vector.【F:multi_pinhole/core.py†L178-L215】
+* Validates the aperture shape and dimensions, promoting scalar inputs to `(height, width)` pairs where appropriate to simplify subsequent math.【F:multi_pinhole/core.py†L217-L266】
+* Records the wavelength band and resets the owning `Camera` link so a camera can claim the eye later.【F:multi_pinhole/core.py†L267-L319】
+
+Operationally, the eye offers:
+
+* `camera2eye`, a vectorized translation that moves world samples (already expressed in the camera frame) into the local optical frame, ready for projection math.【F:multi_pinhole/core.py†L314-L328】
+* `calc_rays`, which filters out geometry behind the focal plane, applies any visibility mask coming from aperture occlusion tests, projects surviving points onto the screen, and computes the magnification required to dilate the eye footprint during rasterization.【F:multi_pinhole/core.py†L330-L372】
+* A set of read-only properties exposing the resolved geometry (type, size, shape, focal length, position, and principal point) and metadata such as the wavelength range or owning `Camera`, keeping the rest of the pipeline loosely coupled.【F:multi_pinhole/core.py†L374-L409】
+
+## Aperture
+`Aperture` describes the physical opening that limits light reaching an eye. It accepts analytic shapes (circle, ellipse, rectangle) or an STL mesh, generates STL geometry when needed, and stores placement and orientation relative to the camera screen.【F:multi_pinhole/core.py†L419-L528】 The STL representation is also used for visibility checks when rasterizing rays, ensuring only unobstructed paths contribute to the final image.【F:multi_pinhole/core.py†L1558-L1583】
+
+## Screen
+The `Screen` represents the detector plane and its sampling scheme. Initialization validates the physical shape, pixel grid, and subpixel refinement factor before computing derived quantities such as pixel area, positions, and masks that exclude out-of-aperture regions.【F:multi_pinhole/core.py†L530-L645】  Changing the subpixel resolution rebuilds subpixel coordinates, sparse transform matrices, and mask arrays so downstream rasterizers stay consistent with the requested sampling density.【F:multi_pinhole/core.py†L646-L753】
+
+Supporting utilities include:
+
+* `positions` and `image_mask`, which generate the center coordinates of pixels or subpixels and mark locations outside circular or elliptical screens so they can be zeroed in final images.【F:multi_pinhole/core.py†L754-L799】
+* `cosine` and `etendue_per_subpixel`, which compute angular falloff corrections and local etendue weights based on the active eye’s focal length and pupil size.【F:multi_pinhole/core.py†L802-L845】
+
+For rasterization, the screen provides multiple strategies. `ray2image` performs a straightforward subpixel hit test for each ray footprint, `ray2image2` introduces batching and optional parallelism for large ray counts, and `ray2image_grid` accelerates the process by clipping to subpixel tiles before applying exact ellipse/rectangle membership tests. All variants construct sparse CSC matrices whose rows correspond to subpixels and whose columns correspond to rays, scaled by the appropriate etendue weights.【F:multi_pinhole/core.py†L846-L1165】
+
+Finally, helper routines cover coordinate transforms (`xy2uv`, `uv2subpixel_index`), accumulation (`subpixel_to_pixel`), and visualization (`show_image`), ensuring the simulated detector data can be reshaped or displayed without ad-hoc code in higher layers.【F:multi_pinhole/core.py†L1167-L1479】
+
+## Camera
+`Camera` ties together one or more `Eye` instances, associated `Aperture` objects, and a `Screen`, while positioning and orienting the assembly in world space. Construction enforces consistent eye types, checks that screen sampling is fine enough for the smallest eye, and stores rotation/translation state.【F:multi_pinhole/core.py†L1330-L1421】 Core responsibilities are:
+- Managing world transforms, movement, and rotation so that world coordinates can be mapped into the camera frame via `world2camera`, while exposing convenient accessors for the camera axes, pose, and child objects.【F:multi_pinhole/core.py†L1384-L1527】
+- Generating image vectors with `calc_image_vec`, which evaluates aperture visibility through STL intersection tests, requests ray bundles from the target eye, and delegates to the screen’s rasterizer to assemble sparse detector responses.【F:multi_pinhole/core.py†L1558-L1587】
+- Providing visualization helpers (`draw_optical_system`, `draw_camera_orientation_plotly`, `draw_camera_orientation`) to inspect optical layouts in Matplotlib or Plotly, facilitating alignment and debugging.【F:multi_pinhole/core.py†L1589-L1786】
+
+Together these classes provide the foundation for higher-level modules (such as `world` and `voxel`) to simulate complex multi-aperture imaging experiments.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,25 @@
+# Project Overview
+
+## Purpose
+The multi-pinhole project simulates imaging systems that combine multiple pinhole or concave-lens "eyes" with configurable screens, apertures, and world geometry. The core module formalizes the optical coordinate systems that tie the world, camera, pinhole, and image spaces together, which enables consistent ray tracing across components.【F:multi_pinhole/core.py†L38-L99】 This foundation supports building cameras with multiple optical channels and capturing their interaction with voxelized scenes and STL-defined structures.
+
+## Key Components
+- **Core optics** – `multi_pinhole.core` defines reusable classes for rays, eyes, apertures, screens, and cameras, along with utilities for projecting 3D world points onto image planes and visualizing the optical layout.【F:multi_pinhole/core.py†L101-L1804】
+- **Voxel modeling** – `multi_pinhole.voxel` provides coordinate transforms (Cartesian, toroidal, cylindrical, spherical) and voxel grid logic for representing plasma or other volumetric targets inside the world.【F:multi_pinhole/voxel.py†L10-L160】
+- **World orchestration** – `multi_pinhole.world` binds voxels, cameras, and optional walls into a simulation-ready environment, manages visibility checks, and exposes helpers for summarizing or persisting a scenario.【F:multi_pinhole/world.py†L70-L167】
+
+## Typical Workflow
+1. **Describe the scene** by instantiating a `Voxel` (or using helpers such as `shifted_torus` or `helical_island`) and optional STL meshes that bound the environment.【F:multi_pinhole/voxel.py†L10-L160】【F:multi_pinhole/world.py†L70-L118】
+2. **Configure optics** by creating one or more `Eye` objects, pairing them with `Aperture` geometries, and attaching them to a `Screen` that defines pixel and subpixel sampling.【F:multi_pinhole/core.py†L177-L1041】
+3. **Assemble a camera** by combining the eyes, apertures, and screen, positioning and orienting the rig in world space, and linking it to the world container.【F:multi_pinhole/core.py†L1330-L1560】【F:multi_pinhole/world.py†L97-L118】
+4. **Project world points** using `Camera.calc_image_vec`, which converts world coordinates to camera coordinates, filters visibility through apertures, computes rays per eye, and rasterizes their footprint onto the screen’s sparse image representation.【F:multi_pinhole/core.py†L1558-L1587】
+5. **Inspect results** by converting subpixel responses to pixel images or plotting camera and optical layouts for debugging and presentation.【F:multi_pinhole/core.py†L1042-L1804】
+
+## Notable Capabilities
+- Multiple coordinate systems (Cartesian, cylindrical, toroidal, spherical) make it easier to model devices with complex symmetries while still rendering them through a consistent camera interface.【F:multi_pinhole/core.py†L38-L90】【F:multi_pinhole/voxel.py†L10-L160】
+- Aperture support accepts analytic shapes or STL meshes, allowing detailed mechanical masks to gate light paths.【F:multi_pinhole/core.py†L425-L544】
+- Screen sampling uses sparse matrices to efficiently accumulate contributions from millions of rays while supporting subpixel refinement and etendue-aware weighting.【F:multi_pinhole/core.py†L546-L1320】
+- Camera utilities include 3D Matplotlib and Plotly visualizations that show optical axes, screen geometry, and apertures for alignment checks.【F:multi_pinhole/core.py†L1589-L1786】
+
+## Extensibility
+The project layers utility functions (e.g., STL processing, filter characteristics) beneath the main classes so that new optical elements or custom workflows can tap into existing coordinate transforms, visibility checks, and visualization routines without re-implementing the core math.【F:multi_pinhole/core.py†L133-L1586】【F:multi_pinhole/world.py†L70-L167】 Future improvements can add richer material models, additional lens types, or automated calibration while reusing the documented interfaces.

--- a/doc/utilities.md
+++ b/doc/utilities.md
@@ -1,0 +1,21 @@
+# Utilities Overview
+
+The `utils` package collects helper functions that support the optical simulation without cluttering the core camera logic. These utilities cover input validation, progress-aware logging, STL mesh processing, and filter-transmission lookup.
+
+## Collection Helpers
+`utils.type_check_and_list` normalizes optional constructor arguments into lists while validating element types. It also accepts a default fallback when `None` is provided, allowing world and camera constructors to treat single objects and lists uniformly.【F:utils/__init__.py†L1-L38】
+
+## Console Wrappers
+`utils.my_stdio` wraps common iteration primitives with optional progress displays. `my_print` gates log messages on a `show` flag, `my_range` and `my_tqdm` defer to `tqdm` versions when verbosity is enabled, and `my_zip` pairs iterables with progress bars via `tzip`. These adapters let long-running geometry routines expose progress feedback without hard-coding dependencies on `tqdm` in calling code.【F:utils/my_stdio.py†L1-L28】
+
+## STL Geometry Toolkit
+`utils.stl_utils` provides extensive support for constructing and analyzing STL meshes used by apertures and world walls. Highlights include:
+
+- `shape_check` and `generate_aperture_stl`, which validate analytic aperture dimensions and synthesize 2D STL meshes for circles, ellipses, and rectangles.【F:utils/stl_utils.py†L34-L155】
+- `rotate_model` and `copy_model`, convenience functions for duplicating meshes and applying translations or Euler-angle rotations without mutating the originals.【F:utils/stl_utils.py†L158-L216】
+- Visibility primitives such as `check_intersection` and `check_visible`, combining fast cone tests with Möller–Trumbore ray-triangle intersection to determine whether rays between an eye and grid points are occluded by geometry.【F:utils/stl_utils.py†L218-L643】
+
+These routines are consumed by `World` and `Camera` to test aperture and wall occlusion efficiently during projection.
+
+## Filter Transmission Data
+`utils.filter` automates retrieval and interpolation of X-ray filter transparency curves. `get_data_from_CXRO` drives the CXRO website via Selenium to download tabulated transmission data, while `get_data` caches the results locally for repeat runs. The `exp_fit` helper fits an exponential attenuation law, and `characteristic` returns a callable that predicts transparency across energies for arbitrary film thicknesses using interpolated coefficients.【F:utils/filter.py†L1-L135】 This data feeds into `Filter.get_data` within the core module to model spectral filtering accurately.

--- a/doc/world.md
+++ b/doc/world.md
@@ -1,0 +1,20 @@
+# World Module Guide
+
+The `multi_pinhole.world` module coordinates cameras, voxels, and occluding geometry into a complete simulation scene. It exposes helpers for managing world assets, persisting scenarios, and rasterizing voxel emission into camera images.
+
+## Construction
+`World` accepts optional voxel, camera, wall, and inside-function inputs. Missing values are replaced with defaults, after which each component is linked back to the world so they can request shared state when projecting rays.【F:multi_pinhole/world.py†L38-L118】 Cameras are normalized into a dictionary keyed by index, letting the world track per-camera visibility masks and projection matrices alongside the optical hardware.【F:multi_pinhole/world.py†L76-L118】
+
+Walls, when provided, are validated as STL meshes and cached together with their bounding boxes, allowing later visibility checks to skip empty scenes quickly.【F:multi_pinhole/world.py†L119-L151】【F:multi_pinhole/world.py†L252-L276】 The constructor also primes bookkeeping for inside-vertex masks, per-eye projections, and sparse image operators so subsequent calls can reuse or refresh cached data as needed.【F:multi_pinhole/world.py†L99-L151】 Supplying an `inside_func` immediately seeds the inside-vertex mask, which is otherwise inferred lazily.【F:multi_pinhole/world.py†L153-L171】
+
+## Scene Introspection
+Utility methods such as `camera_info` and `voxel_info` summarize the active optics and grid, while the `save_world`/`load_world` pair persists complete scenarios using `dill` so experiments can be checkpointed and restored.【F:multi_pinhole/world.py†L173-L220】 Rich property setters ensure updates propagate appropriately: replacing the voxel clears cached projections, changing cameras preserves any reusable matrices, and swapping wall meshes refreshes visibility tables.【F:multi_pinhole/world.py†L222-L321】【F:multi_pinhole/world.py†L330-L384】
+
+## Visibility Management
+World maintains boolean masks that describe which voxel vertices are inside the region of interest and which are visible from each eye. `set_inside_vertices` evaluates a user-supplied predicate over the voxel grid, while `_find_visible_points` transforms candidate points into camera coordinates, checks them against aperture and wall meshes, and returns per-eye visibility flags.【F:multi_pinhole/world.py†L386-L480】【F:multi_pinhole/world.py†L432-L474】 The higher-level `_find_visible_vertices` orchestrates this process for all cameras, caching the results so expensive ray-casting runs are reused unless forced to refresh.【F:multi_pinhole/world.py†L482-L546】
+
+## Projection Assembly
+Once visibility is known, `_find_visible_voxels` and `_calculate_projection_matrix` (invoked through `set_projection_matrix`) build sparse matrices that map voxel emission to detector subpixels.【F:multi_pinhole/world.py†L548-L748】【F:multi_pinhole/world.py†L748-L889】 The implementation batches sub-voxel centers, queries each camera for projected footprints, and multiplies the resulting sparse operators to yield the final projection. Work chunks are sized adaptively based on sampling density so that large scenes remain tractable even with many voxels.【F:multi_pinhole/world.py†L700-L889】 Parallel execution via `joblib` allows heavy projection calculations to utilize multiple CPU cores when requested.【F:multi_pinhole/world.py†L818-L889】
+
+## Accessing Results
+`set_projection_matrix` populates `World._projection` with per-camera, per-eye sparse matrices and caches a combined `P_matrix` when all pieces are available.【F:multi_pinhole/world.py†L891-L949】 Callers can then retrieve visible voxels, projection blocks, and the assembled operator to analyze or render simulated images without recomputing the expensive geometry pipeline.【F:multi_pinhole/world.py†L222-L251】【F:multi_pinhole/world.py†L891-L949】 Ancillary helpers expose inside-vertex masks and wall ranges so downstream code can cull off-screen geometry or track simulation metadata.【F:multi_pinhole/world.py†L201-L251】


### PR DESCRIPTION
## Summary
- add a world module guide detailing initialization, visibility handling, and projection assembly
- document key helpers in the utils package, including STL geometry utilities and filter data retrieval

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dd687aecd48323b4eada69e09fdab0